### PR TITLE
Hotfix numpy versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 description = "Specify step and flyscan paths in a serializable, efficient and Pythonic way"
-dependencies = [
-    "numpy>=2",
-    "click>=8.1",
-    "pydantic>=2.0",
-]
+dependencies = ["numpy", "click>=8.1", "pydantic>=2.0"]
 dynamic = ["version"]
 license.file = "LICENSE"
 readme = "README.md"


### PR DESCRIPTION
Allow ScanSpec to be run with Numpy <2.0