### PR TITLE
Remove the need for uses_tagged_union deco

### DIFF
--- a/src/scanspec/service.py
+++ b/src/scanspec/service.py
@@ -10,7 +10,7 @@ from fastapi.openapi.utils import get_openapi
 from pydantic import Field
 from pydantic.dataclasses import dataclass
 
-from scanspec.core import AxesPoints, Frames, Path, uses_tagged_union
+from scanspec.core import AxesPoints, Frames, Path
 
 from .specs import Line, Spec
 
@@ -25,7 +25,6 @@ app = FastAPI(version="0.1.1")
 Points = str | list[float]
 
 
-@uses_tagged_union
 @dataclass
 class ValidResponse:
     """Response model for spec validation."""
@@ -42,7 +41,6 @@ class PointsFormat(str, Enum):
     BASE64_ENCODED = "BASE64_ENCODED"
 
 
-@uses_tagged_union
 @dataclass
 class PointsRequest:
     """A request for generated scan points."""

--- a/tests/test_basemodel.py
+++ b/tests/test_basemodel.py
@@ -1,12 +1,9 @@
 import pytest
 from pydantic import BaseModel, TypeAdapter
-from pydantic.dataclasses import dataclass
 
-from scanspec.core import StrictConfig, uses_tagged_union
 from scanspec.specs import Line, Spec
 
 
-@uses_tagged_union
 class Foo(BaseModel):
     spec: Spec
 
@@ -41,16 +38,3 @@ def test_type_adapter(model: Foo):
     as_json = model.model_dump_json()
     deserialized = type_adapter.validate_json(as_json)
     assert deserialized == model
-
-
-def test_schema_updates_with_new_values():
-    old_schema = TypeAdapter(Foo).json_schema()
-
-    @dataclass(config=StrictConfig)
-    class Splat(Spec[str]):  # NOSONAR
-        def axes(self) -> list[str]:
-            return ["*"]
-
-    new_schema = TypeAdapter(Foo).json_schema()
-
-    assert new_schema != old_schema


### PR DESCRIPTION
At present we support people adding to the list of Specs after importing the service. This requires a uses_tagged_union decorator on any BaseModel that references a Spec. We cannot currently think of a use case for Specs being implemented outside of scanspec.specs, so removing this requirement means we can ditch the decorator. It also makes the docs (next PR) easier to write:
- Put your specs in src/scanspec/specs.py
- Release a new version
- Update both blueapi and the scanspec service to use that new version