### PR TITLE
Create CLI name variables in new locals mapping

### DIFF
--- a/src/scanspec/cli.py
+++ b/src/scanspec/cli.py
@@ -39,9 +39,8 @@ def plot(spec: str):
     """Plot a scanspec."""
     from scanspec.plot import plot_spec
 
-    for letter in string.ascii_lowercase:
-        locals()[letter] = letter
-    eval_spec = eval(spec)
+    axis_names = {c: c for c in string.ascii_lowercase}
+    eval_spec = eval(spec, locals=axis_names)
     plot_spec(eval_spec)
 
 

--- a/src/scanspec/cli.py
+++ b/src/scanspec/cli.py
@@ -40,8 +40,8 @@ def plot(spec: str):
     from scanspec.plot import plot_spec
 
     axis_names = {c: c for c in string.ascii_lowercase}
-    eval_spec = eval(spec, locals=axis_names)
-    plot_spec(eval_spec)
+    eval_spec = eval(spec, locals=axis_names)  # type: ignore
+    plot_spec(eval_spec)  # type: ignore
 
 
 @cli.command()


### PR DESCRIPTION
In 3.13 the behaviour of the locals builtin changed so that
modifications no longer had any affect in certain situations. This meant
the plot CLI subcommand would raise NameError for single letter axis
names as used in the cli tests.

Passing the locals as a new mapping allows the same code to work with
both the new and old locals behaviour.

Fixes #163

### Instructions to reviewer on how to test:
1. Run tests under Python 3.13 (eg `uv run --extra dev --python 3.13 pytest`)
2. Check tests pass

### Checks for reviewer
- [x] Would the PR title make sense to a user on a set of release notes
