### PR TITLE
167 separate duration out

### DIFF
--- a/src/scanspec/service.py
+++ b/src/scanspec/service.py
@@ -14,7 +14,7 @@ from fastapi.openapi.utils import get_openapi
 from pydantic import Field
 from pydantic.dataclasses import dataclass
 
-from scanspec.core import AxesPoints, Frames, Path
+from scanspec.core import AxesPoints, Dimension, Path
 
 from .specs import Line, Spec
 
@@ -258,7 +258,7 @@ def smallest_step(
 #
 
 
-def _to_chunk(request: PointsRequest) -> tuple[Frames[str], int]:
+def _to_chunk(request: PointsRequest) -> tuple[Dimension[str], int]:
     spec = Spec.deserialize(request.spec)
     dims = spec.calculate()  # Grab dimensions from spec
     path = Path(dims)  # Convert to a path
@@ -305,11 +305,11 @@ def _format_axes_points(
         raise KeyError(f"Unknown format: {format}")
 
 
-def _reduce_frames(stack: list[Frames[str]], max_frames: int) -> Path[str]:
+def _reduce_frames(stack: list[Dimension[str]], max_frames: int) -> Path[str]:
     """Removes frames from a spec so len(path) < max_frames.
 
     Args:
-        stack: A stack of Frames created by a spec
+        stack: A stack of Dimension created by a spec
         max_frames: The maximum number of frames the user wishes to be returned
 
     """
@@ -325,11 +325,11 @@ def _reduce_frames(stack: list[Frames[str]], max_frames: int) -> Path[str]:
     return Path(sub_frames)
 
 
-def _sub_sample(frames: Frames[str], ratio: float) -> Frames[str]:
-    """Provides a sub-sample Frames object whilst preserving its core structure.
+def _sub_sample(frames: Dimension[str], ratio: float) -> Dimension[str]:
+    """Provides a sub-sample Dimension object whilst preserving its core structure.
 
     Args:
-        frames: the Frames object to be reduced
+        frames: the Dimension object to be reduced
         ratio: the reduction ratio of the dimension
 
     """


### PR DESCRIPTION
This PR has two main objectives:

1. Renaming classes to avoid confusing names.
2. Remove **DURATION** from the list of axis.

The PR is still incomplete but it will allow us to discuss important points for the development. 

### Issues to be discussed:

1. Making the Dimensions class accept `None` for the midpoint argument, we will have to handle the check of midpoints in parts of the code where previously it was expected, at least the **midpoints** attribute to exist.
2. Should the **duration** spec have only the duration of each frame and get the amount of frames from the other axis or should it also include a **num** argument

