### PR TITLE
Add Slice class and update consume method

### DIFF
--- a/docs/how-to/iterate-a-spec.rst
+++ b/docs/how-to/iterate-a-spec.rst
@@ -59,12 +59,12 @@ as you need. You can also give a maximum size to `Path.consume()`
 >>> len(path)
 3
 >>> chunk = path.consume(2)
->>> len(chunk)
+>>> len(chunk.midpoints["x"])
 2
 >>> len(path)
 1
 >>> chunk = path.consume(2)
->>> len(chunk)
+>>> len(chunk.midpoints["x"])
 1
 >>> len(path)
 0
@@ -75,7 +75,7 @@ You can also use this method to only run a subset of the scan:
 >>> len(path)
 1
 >>> chunk = path.consume()
->>> len(chunk)
+>>> len(chunk.midpoints["x"])
 1
 >>> len(path)
 0

--- a/src/scanspec/core.py
+++ b/src/scanspec/core.py
@@ -50,7 +50,11 @@ __all__ = [
     "Midpoints",
     "discriminated_union_of_subclasses",
     "StrictConfig",
+    "DURATION",
 ]
+
+#: Can be used as a special key to indicate how long each point should be
+DURATION = "DURATION"
 
 #: Used to ensure pydantic dataclasses error if given extra arguments
 StrictConfig: ConfigDict = {"extra": "forbid", "arbitrary_types_allowed": True}
@@ -288,6 +292,29 @@ OtherAxis = TypeVar("OtherAxis")
 AxesPoints = dict[Axis, npt.NDArray[np.float64]]
 
 
+class Slice(Generic[Axis]):
+    """Generalization of the Dimensions class.
+
+    Only holds information but no methods to handle it.
+    """
+
+    def __init__(
+        self,
+        axes: list[Axis],
+        midpoints: AxesPoints[Axis],
+        gap: GapArray,
+        lower: AxesPoints[Axis] | None = None,
+        upper: AxesPoints[Axis] | None = None,
+        duration: DurationArray | None = None,
+    ):
+        self.axes = axes
+        self.midpoints = midpoints
+        self.lower = lower
+        self.upper = upper
+        self.gap = gap
+        self.duration = duration
+
+
 class Dimension(Generic[Axis]):
     """Represents a series of scan frames along a number of axes.
 
@@ -482,6 +509,68 @@ def _merge_frames(
     )
 
 
+def stack2dimension(
+    dimensions: list[Dimension[Axis]],
+    indices: npt.NDArray[np.signedinteger] | None = None,
+    lengths: npt.NDArray[np.signedinteger] | None = None,
+) -> Dimension[Axis]:
+    if lengths is not None:
+        lengths = lengths
+    else:
+        lengths = np.array([len(f) for f in dimensions])
+
+    if indices is not None:
+        indices = indices
+    else:
+        indices = np.arange(0, int(np.prod(lengths)))
+
+    stack: Dimension[Axis] = Dimension(
+        {},
+        {},
+        {},
+        np.zeros(indices.shape, dtype=np.bool_),
+    )
+    # Example numbers below from a 2x3x4 ZxYxX scan
+    for i, frames in enumerate(dimensions):
+        # Number of times each frame will repeat: Z:12, Y:4, X:1
+        repeats = np.prod(lengths[i + 1 :])
+        # Scan indices mapped to indices within Dimension object:
+        # Z:000000000000111111111111
+        # Y:000011112222000011112222
+        # X:012301230123012301230123
+        if repeats > 1:
+            dim_indices = indices // repeats
+        else:
+            dim_indices = indices
+        # Create the sliced frames
+        sliced = frames.extract(dim_indices, calculate_gap=False)
+        if repeats > 1:
+            # Whether this frames contributes to the gap bit
+            # Z:000000000000100000000000
+            # Y:000010001000100010001000
+            # X:111111111111111111111111
+            in_gap = (indices % repeats) == 0
+            # If in_gap, then keep the relevant gap bit
+            sliced.gap &= in_gap
+        # Zip it with the output Dimension object
+        stack = stack.zip(sliced)
+
+    return stack
+
+
+def dimension2slice(
+    dimension: Dimension[Axis], duration: DurationArray | None
+) -> Slice[Axis]:
+    return Slice(
+        axes=dimension.axes(),
+        midpoints=dimension.midpoints,
+        gap=dimension.gap,
+        upper=dimension.upper,
+        lower=dimension.lower,
+        duration=duration,
+    )
+
+
 class SnakedDimension(Dimension[Axis]):
     """Like a `Dimension` object, but each alternate repetition will run in reverse."""
 
@@ -582,7 +671,7 @@ def squash_frames(
     """
     path = Path(stack)
     # Consuming a Path through these Dimension performs the squash
-    squashed = path.consume()
+    squashed = stack2dimension(stack)
     # Check that the squash is the same as the original
     if stack and isinstance(stack[0], SnakedDimension):
         squashed = SnakedDimension.from_frames(squashed)
@@ -644,7 +733,7 @@ class Path(Generic[Axis]):
         if num is not None and start + num < self.end_index:
             self.end_index = start + num
 
-    def consume(self, num: int | None = None) -> Dimension[Axis]:
+    def consume(self, num: int | None = None) -> Slice[Axis]:
         """Consume at most num frames from the Path and return as a Dimension object.
 
         >>> fx = SnakedDimension({"x": np.array([1, 2])})
@@ -663,34 +752,14 @@ class Path(Generic[Axis]):
             end_index = min(self.index + num, self.end_index)
         indices = np.arange(self.index, end_index)
         self.index = end_index
-        stack: Dimension[Axis] = Dimension(
-            {}, {}, {}, np.zeros(indices.shape, dtype=np.bool_)
-        )
-        # Example numbers below from a 2x3x4 ZxYxX scan
-        for i, frames in enumerate(self.stack):
-            # Number of times each frame will repeat: Z:12, Y:4, X:1
-            repeats = np.prod(self.lengths[i + 1 :])
-            # Scan indices mapped to indices within Dimension object:
-            # Z:000000000000111111111111
-            # Y:000011112222000011112222
-            # X:012301230123012301230123
-            if repeats > 1:
-                dim_indices = indices // repeats
-            else:
-                dim_indices = indices
-            # Create the sliced frames
-            sliced = frames.extract(dim_indices, calculate_gap=False)
-            if repeats > 1:
-                # Whether this frames contributes to the gap bit
-                # Z:000000000000100000000000
-                # Y:000010001000100010001000
-                # X:111111111111111111111111
-                in_gap = (indices % repeats) == 0
-                # If in_gap, then keep the relevant gap bit
-                sliced.gap &= in_gap
-            # Zip it with the output Dimension object
-            stack = stack.zip(sliced)
-        return stack
+
+        stack = stack2dimension(self.stack, indices, self.lengths)
+
+        duration = None
+        if DURATION in stack.axes():
+            duration = stack.midpoints.pop(DURATION)
+
+        return dimension2slice(stack, duration)
 
     def __len__(self) -> int:
         """Number of frames left in a scan, reduces when `consume` is called."""
@@ -738,4 +807,4 @@ class Midpoints(Generic[Axis]):
         path = Path(self.stack)
         while len(path):
             frames = path.consume(1)
-            yield {a: frames.midpoints[a][0] for a in frames.axes()}
+            yield {a: frames.midpoints[a][0] for a in frames.axes}

--- a/src/scanspec/plot.py
+++ b/src/scanspec/plot.py
@@ -12,7 +12,7 @@ from matplotlib.axes import Axes
 from mpl_toolkits.mplot3d import Axes3D, proj3d  # type: ignore
 from scipy import interpolate  # type: ignore
 
-from .core import Path
+from .core import stack2dimension
 from .regions import Circle, Ellipse, Polygon, Rectangle, Region, find_regions
 from .specs import DURATION, Spec
 
@@ -108,8 +108,8 @@ def _plot_spline(
             spline: npt.NDArray[np.float64] = interpolate.splev(tnew, tck)  # type: ignore
             # Scale the splines back to the original scaling
             unscaled_splines = [a * r for a, r in zip(spline, ranges, strict=False)]
-            _plot_arrays(axes, unscaled_splines, color=index_colours[start])
-            yield unscaled_splines
+            _plot_arrays(axes, list(unscaled_splines), color=index_colours[start])  # type: ignore
+            yield unscaled_splines  # type: ignore
 
 
 def plot_spec(spec: Spec[Any], title: str | None = None):
@@ -128,7 +128,7 @@ def plot_spec(spec: Spec[Any], title: str | None = None):
         spec = cube & Circle("x", "y", 1, 2, 0.9)
     """
     dims = spec.calculate()
-    dim = Path(dims).consume()
+    dim = stack2dimension(dims)
     axes = [a for a in spec.axes() if a is not DURATION]
     ndims = len(axes)
 

--- a/src/scanspec/specs.py
+++ b/src/scanspec/specs.py
@@ -20,13 +20,13 @@ from .core import (
     Dimension,
     Midpoints,
     OtherAxis,
-    Path,
     SnakedDimension,
     StrictConfig,
     discriminated_union_of_subclasses,
     gap_between_frames,
     if_instance_do,
     squash_frames,
+    stack2dimension,
 )
 from .regions import Region, get_mask
 
@@ -82,7 +82,7 @@ class Spec(Generic[Axis]):
 
     def frames(self) -> Dimension[Axis]:
         """Expand all the scan `Dimension` and return them."""
-        return Path(self.calculate()).consume()
+        return stack2dimension(self.calculate())
 
     def midpoints(self) -> Midpoints[Axis]:
         """Return `Midpoints` that can be iterated point by point."""

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -49,7 +49,10 @@ def test_subsampling(client: TestClient) -> None:
         "total_frames": 25,
         "returned_frames": 8,
         "format": "FLOAT_LIST",
-        "midpoints": {"x": [0.0, 0.0, 10.0, 10.0], "y": [0.0, 10.0, 0.0, 10.0]},
+        "midpoints": {
+            "x": [0.0, 0.0, 0.0, 0.0, 0.0, 2.5, 2.5, 2.5],
+            "y": [0.0, 2.5, 5.0, 7.5, 10, 0.0, 2.5, 5.0],
+        },
     }
 
 


### PR DESCRIPTION
This PR serves as a middle step to update way we consume a **Path**.
The new **Slice** class contain only information about the scan and it decouples the **DURATION** axis, if present, from the **midpoints** information. This should make checks about the Path slightly easier.

An auxiliary function (**stack2dimension**) was added to guarantee that other parts of the code that used **Path.consume()** still worked without having to change a lot of the code.